### PR TITLE
Rust edition to 2024

### DIFF
--- a/apfs/Cargo.toml
+++ b/apfs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apfs"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "Read-only APFS (Apple File System) parser"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/apfs/src/catalog.rs
+++ b/apfs/src/catalog.rs
@@ -527,11 +527,10 @@ fn lookup_drec<R: Read + Seek>(
     )?;
 
     for (key, val) in &entries {
-        if let Ok(entry_name) = decode_drec_name(key) {
-            if entry_name == name {
+        if let Ok(entry_name) = decode_drec_name(key)
+            && entry_name == name {
                 return DrecVal::parse(val);
             }
-        }
     }
 
     Err(ApfsError::FileNotFound(name.to_string()))

--- a/apfs/src/fletcher.rs
+++ b/apfs/src/fletcher.rs
@@ -2,7 +2,7 @@
 ///
 /// Every on-disk object has a 64-bit checksum at offset 0, computed over
 /// bytes 8..block_size using a modular Fletcher-64 variant.
-
+///
 /// Compute APFS Fletcher-64 checksum over a byte slice.
 ///
 /// The input should be the object data starting at offset 8 (skipping the
@@ -38,8 +38,7 @@ pub fn verify_object(block: &[u8]) -> bool {
     }
 
     let stored = u64::from_le_bytes([
-        block[0], block[1], block[2], block[3],
-        block[4], block[5], block[6], block[7],
+        block[0], block[1], block[2], block[3], block[4], block[5], block[6], block[7],
     ]);
 
     let computed = fletcher64(&block[8..]);
@@ -62,12 +61,14 @@ mod tests {
         assert!(verify_object(&block), "Block 0 checksum should be valid");
 
         let stored = u64::from_le_bytes([
-            block[0], block[1], block[2], block[3],
-            block[4], block[5], block[6], block[7],
+            block[0], block[1], block[2], block[3], block[4], block[5], block[6], block[7],
         ]);
         let computed = fletcher64(&block[8..]);
-        assert_eq!(stored, computed,
-            "Stored checksum 0x{:016X} should match computed 0x{:016X}", stored, computed);
+        assert_eq!(
+            stored, computed,
+            "Stored checksum 0x{:016X} should match computed 0x{:016X}",
+            stored, computed
+        );
     }
 
     #[test]
@@ -79,7 +80,7 @@ mod tests {
         // check2 = M - ((3 + check1) % M) = M - (3 + M - 7) % M = M - (M - 4) % M = M - (M-4) = 4
         let data = [
             1u8, 0, 0, 0, // word 0 = 1
-            2, 0, 0, 0,   // word 1 = 2
+            2, 0, 0, 0, // word 1 = 2
         ];
         let m: u64 = 0xFFFFFFFF;
         let checksum = fletcher64(&data);

--- a/dpp-tool/Cargo.toml
+++ b/dpp-tool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dpp-tool"
 version = "0.3.2"
-edition = "2021"
+edition = "2024"
 description = "CLI to explore Apple DMG disk images: DMG → HFS+/APFS → PKG → PBZX → files"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/dpp-tool/src/cmd_apfs.rs
+++ b/dpp-tool/src/cmd_apfs.rs
@@ -88,8 +88,8 @@ fn ls(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::error:
     header(&format!("{dmg_path}:{path}"));
     println!();
     println!(
-        "  {DIM}{:<5} {:>12}  {}{RESET}",
-        "Kind", "Size", "Name"
+        "  {DIM}{:<5} {:>12}  Name{RESET}",
+        "Kind", "Size"
     );
     println!("  {DIM}{}{RESET}", "-".repeat(56));
 
@@ -306,11 +306,10 @@ fn find(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::erro
     let matches: Vec<_> = entries
         .iter()
         .filter(|e| {
-            if let Some(ref kind) = type_filter {
-                if e.entry.kind != *kind {
+            if let Some(ref kind) = type_filter
+                && e.entry.kind != *kind {
                     return false;
                 }
-            }
             if let Some(ref pattern) = name_pattern {
                 let basename = e.path.rsplit('/').next().unwrap_or(&e.path);
                 if !glob_match(pattern, basename) {

--- a/dpp-tool/src/cmd_bench.rs
+++ b/dpp-tool/src/cmd_bench.rs
@@ -51,12 +51,11 @@ pub(crate) fn run(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn
             kv("Files", &format_commas(vi.file_count));
             kv("Directories", &format_commas(vi.directory_count));
 
-            if let Some(mp) = main_partition {
-                if mp.size > 0 && fs_time.as_secs_f64() > 0.0 {
+            if let Some(mp) = main_partition
+                && mp.size > 0 && fs_time.as_secs_f64() > 0.0 {
                     let throughput = mp.size as f64 / fs_time.as_secs_f64() / (1024.0 * 1024.0);
                     kv_highlight("Throughput", &format!("{:.1} MB/s", throughput));
                 }
-            }
 
             // Stage 3: Filesystem walk
             section("Stage 3: Filesystem Walk (B-tree traversal)");
@@ -105,13 +104,12 @@ pub(crate) fn run(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn
                     };
 
                     // Find payload size
-                    if let Some(payload_file) = pkg.xar().find(&payload_path) {
-                        if let Some(data) = &payload_file.data {
+                    if let Some(payload_file) = pkg.xar().find(&payload_path)
+                        && let Some(data) = &payload_file.data {
                             kv("Component", if comp.is_empty() { "(root)" } else { comp });
                             kv("Compressed payload", &format_size(data.length));
                             kv("Uncompressed payload", &format_size(data.size));
                         }
-                    }
 
                     let mut pkg_mut = fs.open_pkg(&pkg_files[0].path)?;
                     let t = Instant::now();

--- a/dpp-tool/src/cmd_dmg.rs
+++ b/dpp-tool/src/cmd_dmg.rs
@@ -86,7 +86,7 @@ fn ls(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
 
     header(&format!("Partitions: {dmg_path}"));
     println!();
-    println!("  {DIM}{:>4}  {:>12}  {:>12}  {:>12}  {:>7}  {}{RESET}", "ID", "Sectors", "Size", "Compressed", "Ratio", "Name");
+    println!("  {DIM}{:>4}  {:>12}  {:>12}  {:>12}  {:>7}  Name{RESET}", "ID", "Sectors", "Size", "Compressed", "Ratio");
     println!("  {DIM}{}{RESET}", "-".repeat(72));
 
     for p in &partitions {

--- a/dpp-tool/src/cmd_fs.rs
+++ b/dpp-tool/src/cmd_fs.rs
@@ -113,8 +113,8 @@ fn ls(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::error:
     header(&format!("{dmg_path}:{path}"));
     println!();
     println!(
-        "  {DIM}{:<5} {:>12}  {}{RESET}",
-        "Kind", "Size", "Name"
+        "  {DIM}{:<5} {:>12}  Name{RESET}",
+        "Kind", "Size"
     );
     println!("  {DIM}{}{RESET}", "-".repeat(56));
 
@@ -349,11 +349,10 @@ fn find(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::erro
     let matches: Vec<_> = entries
         .iter()
         .filter(|e| {
-            if let Some(ref kind) = type_filter {
-                if e.entry.kind != *kind {
+            if let Some(ref kind) = type_filter
+                && e.entry.kind != *kind {
                     return false;
                 }
-            }
             if let Some(ref pattern) = name_pattern {
                 let basename = e.path.rsplit('/').next().unwrap_or(&e.path);
                 if !glob_match(pattern, basename) {

--- a/dpp-tool/src/cmd_hfs.rs
+++ b/dpp-tool/src/cmd_hfs.rs
@@ -95,8 +95,8 @@ fn ls(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::error:
     header(&format!("{dmg_path}:{path}"));
     println!();
     println!(
-        "  {DIM}{:<5} {:>12}  {}{RESET}",
-        "Kind", "Size", "Name"
+        "  {DIM}{:<5} {:>12}  Name{RESET}",
+        "Kind", "Size"
     );
     println!("  {DIM}{}{RESET}", "-".repeat(56));
 
@@ -320,11 +320,10 @@ fn find(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::erro
     let matches: Vec<_> = entries
         .iter()
         .filter(|e| {
-            if let Some(ref kind) = type_filter {
-                if e.entry.kind != *kind {
+            if let Some(ref kind) = type_filter
+                && e.entry.kind != *kind {
                     return false;
                 }
-            }
             if let Some(ref pattern) = name_pattern {
                 let basename = e.path.rsplit('/').next().unwrap_or(&e.path);
                 if !glob_match(pattern, basename) {

--- a/dpp-tool/src/cmd_info.rs
+++ b/dpp-tool/src/cmd_info.rs
@@ -45,7 +45,7 @@ pub(crate) fn run(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn
 
     // Partition table
     println!();
-    println!("  {DIM}{:>4}  {:>12}  {:>12}  {:>7}  {}{RESET}", "ID", "Sectors", "Size", "Ratio", "Name");
+    println!("  {DIM}{:>4}  {:>12}  {:>12}  {:>7}  Name{RESET}", "ID", "Sectors", "Size", "Ratio");
     println!("  {DIM}{}{RESET}", "-".repeat(58));
     for p in &partitions {
         let ratio = if p.size > 0 {

--- a/dpp-tool/src/cmd_payload.rs
+++ b/dpp-tool/src/cmd_payload.rs
@@ -177,8 +177,8 @@ fn ls(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::error:
     header(&format!("Payload: {} — {display_dir}", args[2]));
     println!();
     println!(
-        "  {DIM}{:<5} {:>12}  {}{RESET}",
-        "Kind", "Size", "Name"
+        "  {DIM}{:<5} {:>12}  Name{RESET}",
+        "Kind", "Size"
     );
     println!("  {DIM}{}{RESET}", "-".repeat(56));
 
@@ -358,11 +358,10 @@ fn find(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::erro
                 }
             }
 
-            if let Some(ref pattern) = name_pattern {
-                if !glob_match(pattern, basename_of(&np)) {
+            if let Some(ref pattern) = name_pattern
+                && !glob_match(pattern, basename_of(&np)) {
                     return false;
                 }
-            }
 
             true
         })

--- a/dpp-tool/src/cmd_pkg.rs
+++ b/dpp-tool/src/cmd_pkg.rs
@@ -278,16 +278,14 @@ fn find(args: &[String], mode: dpp::ExtractMode) -> Result<(), Box<dyn std::erro
     let matches: Vec<_> = files
         .iter()
         .filter(|f| {
-            if let Some(ref kind) = type_filter {
-                if f.file_type != *kind {
+            if let Some(ref kind) = type_filter
+                && f.file_type != *kind {
                     return false;
                 }
-            }
-            if let Some(ref pattern) = name_pattern {
-                if !glob_match(pattern, &f.name) {
+            if let Some(ref pattern) = name_pattern
+                && !glob_match(pattern, &f.name) {
                     return false;
                 }
-            }
             true
         })
         .collect();

--- a/dpp/Cargo.toml
+++ b/dpp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dpp"
 version = "0.3.2"
-edition = "2021"
+edition = "2024"
 description = "DMG + HFS+/APFS + PKG + PBZX pipeline - walk through Apple disk images to extract packages"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/dpp/src/pipeline.rs
+++ b/dpp/src/pipeline.rs
@@ -5,18 +5,15 @@ use crate::error::Result;
 
 /// Extraction mode for partition data
 #[derive(Debug, Clone, Copy)]
+#[derive(Default)]
 pub enum ExtractMode {
     /// Stream to temp file on disk (low memory). Default.
+    #[default]
     TempFile,
     /// Buffer entire partition in memory. Fast for small DMGs.
     InMemory,
 }
 
-impl Default for ExtractMode {
-    fn default() -> Self {
-        ExtractMode::TempFile
-    }
-}
 
 /// Main pipeline entry point: DMG → HFS+/APFS → PKG → PBZX
 pub struct DmgPipeline {

--- a/dpp/src/pipeline.rs
+++ b/dpp/src/pipeline.rs
@@ -4,8 +4,7 @@ use std::path::Path;
 use crate::error::Result;
 
 /// Extraction mode for partition data
-#[derive(Debug, Clone, Copy)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum ExtractMode {
     /// Stream to temp file on disk (low memory). Default.
     #[default]
@@ -13,7 +12,6 @@ pub enum ExtractMode {
     /// Buffer entire partition in memory. Fast for small DMGs.
     InMemory,
 }
-
 
 /// Main pipeline entry point: DMG → HFS+/APFS → PKG → PBZX
 pub struct DmgPipeline {
@@ -62,9 +60,7 @@ impl DmgPipeline {
                 })
             }
             ExtractMode::InMemory => {
-                let partition_data = self
-                    .archive
-                    .extract_partition(partition_id)?;
+                let partition_data = self.archive.extract_partition(partition_id)?;
                 let cursor = Cursor::new(partition_data);
                 let volume = hfsplus::HfsVolume::open(cursor)?;
                 Ok(HfsHandle {
@@ -100,9 +96,7 @@ impl DmgPipeline {
                 })
             }
             ExtractMode::InMemory => {
-                let partition_data = self
-                    .archive
-                    .extract_partition(partition_id)?;
+                let partition_data = self.archive.extract_partition(partition_id)?;
                 let cursor = Cursor::new(partition_data);
                 let volume = apfs::ApfsVolume::open(cursor)?;
                 Ok(ApfsHandle {
@@ -124,14 +118,19 @@ impl DmgPipeline {
         let partitions = self.archive.partitions();
 
         // Check for HFS+/HFSX partition first (preserves current priority)
-        let has_hfs = partitions.iter()
-            .any(|p| matches!(p.partition_type, udif::PartitionType::Hfs | udif::PartitionType::Hfsx));
+        let has_hfs = partitions.iter().any(|p| {
+            matches!(
+                p.partition_type,
+                udif::PartitionType::Hfs | udif::PartitionType::Hfsx
+            )
+        });
 
         if has_hfs {
             return self.open_hfs_with_mode(mode).map(FilesystemHandle::Hfs);
         }
 
-        let has_apfs = partitions.iter()
+        let has_apfs = partitions
+            .iter()
             .any(|p| p.partition_type == udif::PartitionType::Apfs);
 
         if has_apfs {
@@ -188,11 +187,7 @@ impl HfsHandle {
     }
 
     /// Stream a file to a writer (low memory)
-    pub fn read_file_to<W: std::io::Write>(
-        &mut self,
-        path: &str,
-        writer: &mut W,
-    ) -> Result<u64> {
+    pub fn read_file_to<W: std::io::Write>(&mut self, path: &str, writer: &mut W) -> Result<u64> {
         Ok(dispatch!(self, read_file_to, path, writer)?)
     }
 
@@ -278,11 +273,7 @@ impl ApfsHandle {
     }
 
     /// Stream a file to a writer (low memory)
-    pub fn read_file_to<W: std::io::Write>(
-        &mut self,
-        path: &str,
-        writer: &mut W,
-    ) -> Result<u64> {
+    pub fn read_file_to<W: std::io::Write>(&mut self, path: &str, writer: &mut W) -> Result<u64> {
         Ok(dispatch_apfs!(self, read_file_to, path, writer)?)
     }
 
@@ -520,6 +511,7 @@ pub struct FsVolumeInfo {
 
 /// Unified handle to either an HFS+ or APFS volume.
 /// Returned by `DmgPipeline::open_filesystem()`.
+#[allow(clippy::large_enum_variant)]
 pub enum FilesystemHandle {
     Hfs(HfsHandle),
     Apfs(ApfsHandle),
@@ -603,11 +595,7 @@ impl FilesystemHandle {
     }
 
     /// Stream a file to a writer
-    pub fn read_file_to<W: std::io::Write>(
-        &mut self,
-        path: &str,
-        writer: &mut W,
-    ) -> Result<u64> {
+    pub fn read_file_to<W: std::io::Write>(&mut self, path: &str, writer: &mut W) -> Result<u64> {
         match self {
             FilesystemHandle::Hfs(h) => h.read_file_to(path, writer),
             FilesystemHandle::Apfs(h) => h.read_file_to(path, writer),

--- a/hfsplus/Cargo.toml
+++ b/hfsplus/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hfsplus"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "Read-only HFS+ / HFSX filesystem parser"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/hfsplus/src/catalog.rs
+++ b/hfsplus/src/catalog.rs
@@ -110,7 +110,7 @@ fn parse_catalog_key(data: &[u8]) -> Result<(CatalogKey, usize)> {
     // Record data starts after key_length + 2 bytes for the key_length field itself
     let record_offset = 2 + key_length;
     // Ensure even alignment
-    let record_offset = if record_offset % 2 != 0 { record_offset + 1 } else { record_offset };
+    let record_offset = if !record_offset.is_multiple_of(2) { record_offset + 1 } else { record_offset };
 
     Ok((
         CatalogKey {

--- a/hfsplus/src/unicode.rs
+++ b/hfsplus/src/unicode.rs
@@ -1,8 +1,8 @@
-/// HFS+ Unicode comparison utilities.
-///
-/// HFSX (case-sensitive) uses binary comparison of UTF-16BE values.
-/// HFS+ (case-insensitive) uses Apple's FastUnicodeCompare with a
-/// case-folding table defined in Apple TN1150.
+//! HFS+ Unicode comparison utilities.
+//!
+//! HFSX (case-sensitive) uses binary comparison of UTF-16BE values.
+//! HFS+ (case-insensitive) uses Apple's FastUnicodeCompare with a
+//! case-folding table defined in Apple TN1150.
 
 /// Compare two HFS+ Unicode names using binary comparison (HFSX / case-sensitive).
 pub fn compare_binary(a: &[u16], b: &[u16]) -> std::cmp::Ordering {

--- a/hfsplus/src/volume.rs
+++ b/hfsplus/src/volume.rs
@@ -25,6 +25,7 @@ pub struct ExtentDescriptor {
 
 /// Fork data: describes a data or resource fork
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct ForkData {
     pub logical_size: u64,
     pub clump_size: u32,
@@ -32,16 +33,6 @@ pub struct ForkData {
     pub extents: [ExtentDescriptor; 8],
 }
 
-impl Default for ForkData {
-    fn default() -> Self {
-        ForkData {
-            logical_size: 0,
-            clump_size: 0,
-            total_blocks: 0,
-            extents: [ExtentDescriptor::default(); 8],
-        }
-    }
-}
 
 /// The HFS+ Volume Header (512 bytes at offset 1024)
 #[derive(Debug, Clone)]

--- a/pbzx/Cargo.toml
+++ b/pbzx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pbzx"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "A Rust library for parsing, extracting, and creating PBZX archives (Apple's payload format)"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/pbzx/src/writer.rs
+++ b/pbzx/src/writer.rs
@@ -278,14 +278,14 @@ impl CpioBuilder {
         // Pad to 4-byte boundary
         let header_len = 110 + namesize;
         let padding = (4 - (header_len % 4)) % 4;
-        self.data.extend(std::iter::repeat(0).take(padding));
+        self.data.extend(std::iter::repeat_n(0, padding));
 
         // Write file data
         self.data.extend_from_slice(data);
 
         // Pad data to 4-byte boundary
         let data_padding = (4 - (data.len() % 4)) % 4;
-        self.data.extend(std::iter::repeat(0).take(data_padding));
+        self.data.extend(std::iter::repeat_n(0, data_padding));
     }
 
     /// Finish the archive and return the CPIO data.

--- a/udif/Cargo.toml
+++ b/udif/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "udif"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 description = "cross-platform Apple disk image (aka DMG, UDIF) library"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/udif/src/writer.rs
+++ b/udif/src/writer.rs
@@ -111,7 +111,7 @@ impl<W: Write + Seek> DmgWriter<W> {
 
     /// Add raw disk data as a partition
     pub fn add_partition(&mut self, name: &str, data: &[u8]) -> Result<()> {
-        let sector_count = (data.len() as u64 + SECTOR_SIZE - 1) / SECTOR_SIZE;
+        let sector_count = (data.len() as u64).div_ceil(SECTOR_SIZE);
         let first_sector = self.partitions.iter().map(|p| p.first_sector + p.sector_count).max().unwrap_or(0);
 
         let mut block_runs = Vec::new();
@@ -132,7 +132,7 @@ impl<W: Write + Seek> DmgWriter<W> {
         while data_offset < data.len() {
             let chunk_end = (data_offset + self.chunk_size).min(data.len());
             let chunk = &data[data_offset..chunk_end];
-            let chunk_sectors = ((chunk.len() as u64 + SECTOR_SIZE - 1) / SECTOR_SIZE).max(1);
+            let chunk_sectors = (chunk.len() as u64).div_ceil(SECTOR_SIZE).max(1);
 
             // Check if chunk is all zeros
             if chunk.iter().all(|&b| b == 0) {

--- a/xara/Cargo.toml
+++ b/xara/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xara"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "Read-only XAR archive and macOS PKG package parser"
 license = "MIT"
 repository = "https://github.com/Dil4rd/dpp"

--- a/xara/src/pkg.rs
+++ b/xara/src/pkg.rs
@@ -51,11 +51,10 @@ impl<R: Read + Seek> PkgReader<R> {
         }
 
         // If no .pkg directories found, this is a component package
-        if components.is_empty() {
-            if self.xar.find("Payload").is_some() || self.xar.find("PackageInfo").is_some() {
+        if components.is_empty()
+            && (self.xar.find("Payload").is_some() || self.xar.find("PackageInfo").is_some()) {
                 components.push(String::new());
             }
-        }
 
         components
     }

--- a/xara/src/toc.rs
+++ b/xara/src/toc.rs
@@ -185,9 +185,9 @@ fn parse_toc_xml(xml: &[u8]) -> Result<Vec<XarFile>> {
             }
             Ok(Event::Empty(ref e)) => {
                 let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
-                if tag == "encoding" {
-                    if let Some(f) = stack.last_mut() {
-                        if f.in_data {
+                if tag == "encoding"
+                    && let Some(f) = stack.last_mut()
+                        && f.in_data {
                             for attr in e.attributes().flatten() {
                                 if attr.key.as_ref() == b"style" {
                                     f.data_encoding = Some(
@@ -196,8 +196,6 @@ fn parse_toc_xml(xml: &[u8]) -> Result<Vec<XarFile>> {
                                 }
                             }
                         }
-                    }
-                }
             }
             Ok(Event::Text(ref e)) => {
                 let text = e.unescape().unwrap_or_default().to_string();


### PR DESCRIPTION
1. Update rust edition to `2024`
2. Run `cargo clippy --fix`
3. Fix other clippy warnings that were not auto fixed

Please run `cargo fmt` after merging this