### PR TITLE
apfs: read symlink targets from the com.apple.fs.symlink xattr

### DIFF
--- a/apfs/CHANGELOG.md
+++ b/apfs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `ApfsError::Unsupported` for images that use a feature the reader does not implement, keeping those cases distinct from `CorruptedData`
+
 ## [0.2.4] - 2026-04-12
 
 ### Changed

--- a/apfs/CHANGELOG.md
+++ b/apfs/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - `ApfsError::Unsupported` for images that use a feature the reader does not implement, keeping those cases distinct from `CorruptedData`
+- `catalog::lookup_xattr` and `catalog::SYMLINK_XATTR_NAME` for reading an inode's extended attribute by name. Attributes stored as a data stream rather than embedded in the record are reported as `ApfsError::Unsupported`
+
+### Fixed
+
+- Symlink targets are now read from the `com.apple.fs.symlink` extended attribute, where APFS stores them. `read_file` and `read_file_to` previously returned empty data for every symlink, and `stat` reported size 0, because symlink inodes carry no extents
 
 ## [0.2.4] - 2026-04-12
 

--- a/apfs/src/catalog.rs
+++ b/apfs/src/catalog.rs
@@ -28,6 +28,9 @@ pub const INODE_DIR_TYPE: u16 = 0o040000; // S_IFDIR
 pub const INODE_FILE_TYPE: u16 = 0o100000; // S_IFREG
 pub const INODE_SYMLINK_TYPE: u16 = 0o120000; // S_IFLNK
 
+/// Name of the extended attribute that stores symlink targets on APFS.
+pub const SYMLINK_XATTR_NAME: &str = "com.apple.fs.symlink";
+
 // Extended field types (INO_EXT_TYPE_*)
 const INO_EXT_TYPE_DSTREAM: u8 = 8;
 
@@ -458,6 +461,57 @@ pub fn lookup_extents<R: Read + Seek>(
     Ok(extents)
 }
 
+/// Look up an extended attribute value for an inode.
+///
+/// Xattr catalog keys are `[obj_id_and_type u64][name_len u16][name\0]`, so
+/// the lookup compares the OID/type first, then the NUL-terminated name.
+pub fn lookup_xattr<R: Read + Seek>(
+    reader: &mut R,
+    catalog_root: u64,
+    omap_root: u64,
+    block_size: u32,
+    oid: u64,
+    name: &str,
+) -> Result<Option<Vec<u8>>> {
+    // Build the search key: obj_id_and_type | name_len (incl. NUL) | name | NUL
+    let mut search_key = Vec::with_capacity(8 + 2 + name.len() + 1);
+    let obj_id_and_type = (oid & 0x0FFFFFFFFFFFFFFF) | ((J_TYPE_XATTR as u64) << 60);
+    search_key.extend_from_slice(&obj_id_and_type.to_le_bytes());
+    search_key.extend_from_slice(&((name.len() + 1) as u16).to_le_bytes());
+    search_key.extend_from_slice(name.as_bytes());
+    search_key.push(0);
+
+    // Catalog keys are sorted as raw bytes; compare the common prefix, then length.
+    let compare_fn = |key: &[u8]| -> std::cmp::Ordering {
+        let prefix = key.len().min(search_key.len());
+        match key[..prefix].cmp(&search_key[..prefix]) {
+            std::cmp::Ordering::Equal => key.len().cmp(&search_key.len()),
+            ord => ord,
+        }
+    };
+
+    btree::btree_lookup(
+        reader,
+        catalog_root,
+        block_size,
+        0,
+        0,
+        &compare_fn,
+        Some(omap_root),
+    )
+}
+
+/// Parse an xattr record value: `flags u16 | data_len u16 | data`.
+/// Returns the raw xattr data (without the header).
+pub fn parse_xattr_value(value: &[u8]) -> Vec<u8> {
+    if value.len() < 4 {
+        return value.to_vec();
+    }
+    let data_len = u16::from_le_bytes([value[2], value[3]]) as usize;
+    let end = value.len().min(4 + data_len);
+    value[4..end].to_vec()
+}
+
 /// Resolve a path like "/Applications/Upscayl.app/Contents/Info.plist" to its (OID, InodeVal).
 pub fn resolve_path<R: Read + Seek>(
     reader: &mut R,
@@ -568,6 +622,40 @@ mod tests {
     use crate::omap as omap_mod;
     use crate::superblock;
     use std::io::BufReader;
+
+    #[test]
+    fn parses_xattr_value_header() {
+        // flags=0x0006, data_len=0x000e, data = "../README.txt\0"
+        let value = [
+            0x06, 0x00, 0x0e, 0x00, b'.', b'.', b'/', b'R', b'E', b'A', b'D', b'M', b'E', b'.',
+            b't', b'x', b't', b'\0',
+        ];
+        assert_eq!(parse_xattr_value(&value), b"../README.txt\0".to_vec());
+        // data_len larger than the record: clamp to the value length
+        let short = [0x06, 0x00, 0xff, 0x00, b'a', b'b'];
+        assert_eq!(parse_xattr_value(&short), b"ab".to_vec());
+        // value shorter than the header: pass through
+        assert_eq!(parse_xattr_value(b"abc"), b"abc".to_vec());
+    }
+
+    #[test]
+    fn builds_xattr_search_key_layout() {
+        // The search key must match the on-disk j_xattr_key_t layout:
+        // obj_id_and_type | name_len (incl. NUL) | name | NUL
+        let oid = 25_u64;
+        let name = "com.apple.fs.symlink";
+        let mut key = Vec::with_capacity(8 + 2 + name.len() + 1);
+        let obj_id_and_type = (oid & 0x0FFFFFFFFFFFFFFF) | ((J_TYPE_XATTR as u64) << 60);
+        key.extend_from_slice(&obj_id_and_type.to_le_bytes());
+        key.extend_from_slice(&((name.len() + 1) as u16).to_le_bytes());
+        key.extend_from_slice(name.as_bytes());
+        key.push(0);
+        assert_eq!(key.len(), 31);
+        assert_eq!(key[0], 0x19); // oid 25, low byte
+        assert_eq!(key[7], 0x40); // J_TYPE_XATTR nibble
+        assert_eq!(&key[8..10], &[0x15, 0x00]); // name_len 21
+        assert_eq!(&key[10..31], b"com.apple.fs.symlink\0");
+    }
 
     fn open_volume() -> (BufReader<std::fs::File>, u64, u64, u32) {
         let file = std::fs::File::open("../tests/appfs.raw").unwrap();

--- a/apfs/src/catalog.rs
+++ b/apfs/src/catalog.rs
@@ -31,6 +31,13 @@ pub const INODE_SYMLINK_TYPE: u16 = 0o120000; // S_IFLNK
 /// Name of the extended attribute that stores symlink targets on APFS.
 pub const SYMLINK_XATTR_NAME: &str = "com.apple.fs.symlink";
 
+/// Offset of the attribute name within an xattr catalog key: the 8-byte
+/// `obj_id_and_type` followed by the 2-byte `name_len`.
+const XATTR_KEY_NAME_OFFSET: usize = 10;
+
+// Xattr record flags (j_xattr_flags)
+const XATTR_DATA_STREAM: u16 = 0x0001;
+
 // Extended field types (INO_EXT_TYPE_*)
 const INO_EXT_TYPE_DSTREAM: u8 = 8;
 
@@ -461,10 +468,35 @@ pub fn lookup_extents<R: Read + Seek>(
     Ok(extents)
 }
 
+/// Order an on-disk xattr catalog key against the `(oid, name)` being searched for.
+///
+/// Catalog records sort by OID, then by record type, and xattr records then sort
+/// by the NUL-terminated attribute name. The name is preceded in the key by a
+/// `name_len` field, so the tie-break skips it rather than comparing key bytes
+/// straight through.
+fn compare_xattr_key(key: &[u8], oid: u64, name_with_nul: &[u8]) -> std::cmp::Ordering {
+    let Ok((key_oid, key_type)) = decode_catalog_key(key) else {
+        return std::cmp::Ordering::Less;
+    };
+    match compare_catalog_keys(key_oid, key_type, oid, J_TYPE_XATTR) {
+        std::cmp::Ordering::Equal => key
+            .get(XATTR_KEY_NAME_OFFSET..)
+            .unwrap_or(&[])
+            .cmp(name_with_nul),
+        ord => ord,
+    }
+}
+
 /// Look up an extended attribute value for an inode.
 ///
 /// Xattr catalog keys are `[obj_id_and_type u64][name_len u16][name\0]`, so
 /// the lookup compares the OID/type first, then the NUL-terminated name.
+///
+/// Returns the attribute data with its record header removed, or `None` when
+/// the inode carries no attribute of that name. Attributes stored as a data
+/// stream rather than embedded in the record are rejected with
+/// [`ApfsError::Unsupported`], since the record holds a dstream reference in
+/// place of the value.
 pub fn lookup_xattr<R: Read + Seek>(
     reader: &mut R,
     catalog_root: u64,
@@ -473,24 +505,12 @@ pub fn lookup_xattr<R: Read + Seek>(
     oid: u64,
     name: &str,
 ) -> Result<Option<Vec<u8>>> {
-    // Build the search key: obj_id_and_type | name_len (incl. NUL) | name | NUL
-    let mut search_key = Vec::with_capacity(8 + 2 + name.len() + 1);
-    let obj_id_and_type = (oid & 0x0FFFFFFFFFFFFFFF) | ((J_TYPE_XATTR as u64) << 60);
-    search_key.extend_from_slice(&obj_id_and_type.to_le_bytes());
-    search_key.extend_from_slice(&((name.len() + 1) as u16).to_le_bytes());
-    search_key.extend_from_slice(name.as_bytes());
-    search_key.push(0);
+    let mut search_name = Vec::with_capacity(name.len() + 1);
+    search_name.extend_from_slice(name.as_bytes());
+    search_name.push(0);
+    let compare_fn = |key: &[u8]| compare_xattr_key(key, oid, &search_name);
 
-    // Catalog keys are sorted as raw bytes; compare the common prefix, then length.
-    let compare_fn = |key: &[u8]| -> std::cmp::Ordering {
-        let prefix = key.len().min(search_key.len());
-        match key[..prefix].cmp(&search_key[..prefix]) {
-            std::cmp::Ordering::Equal => key.len().cmp(&search_key.len()),
-            ord => ord,
-        }
-    };
-
-    btree::btree_lookup(
+    let value = btree::btree_lookup(
         reader,
         catalog_root,
         block_size,
@@ -498,18 +518,35 @@ pub fn lookup_xattr<R: Read + Seek>(
         0,
         &compare_fn,
         Some(omap_root),
-    )
+    )?;
+
+    match value {
+        Some(value) => Ok(Some(parse_xattr_value(&value)?)),
+        None => Ok(None),
+    }
 }
 
 /// Parse an xattr record value: `flags u16 | data_len u16 | data`.
-/// Returns the raw xattr data (without the header).
-pub fn parse_xattr_value(value: &[u8]) -> Vec<u8> {
+///
+/// Only embedded attributes are supported. A record flagged `XATTR_DATA_STREAM`
+/// carries a dstream reference in place of the data, so returning its bytes
+/// would hand back the reference struct as though it were the value.
+fn parse_xattr_value(value: &[u8]) -> Result<Vec<u8>> {
     if value.len() < 4 {
-        return value.to_vec();
+        return Err(ApfsError::CorruptedData(format!(
+            "xattr value too short: {} bytes",
+            value.len()
+        )));
+    }
+    let flags = u16::from_le_bytes([value[0], value[1]]);
+    if flags & XATTR_DATA_STREAM != 0 {
+        return Err(ApfsError::Unsupported(
+            "xattr is stored as a data stream, not embedded in the record".into(),
+        ));
     }
     let data_len = u16::from_le_bytes([value[2], value[3]]) as usize;
     let end = value.len().min(4 + data_len);
-    value[4..end].to_vec()
+    Ok(value[4..end].to_vec())
 }
 
 /// Resolve a path like "/Applications/Upscayl.app/Contents/Info.plist" to its (OID, InodeVal).
@@ -625,36 +662,111 @@ mod tests {
 
     #[test]
     fn parses_xattr_value_header() {
-        // flags=0x0006, data_len=0x000e, data = "../README.txt\0"
+        // flags=0x0006 (embedded), data_len=0x000e, data = "../README.txt\0"
         let value = [
             0x06, 0x00, 0x0e, 0x00, b'.', b'.', b'/', b'R', b'E', b'A', b'D', b'M', b'E', b'.',
             b't', b'x', b't', b'\0',
         ];
-        assert_eq!(parse_xattr_value(&value), b"../README.txt\0".to_vec());
+        assert_eq!(
+            parse_xattr_value(&value).unwrap(),
+            b"../README.txt\0".to_vec()
+        );
         // data_len larger than the record: clamp to the value length
         let short = [0x06, 0x00, 0xff, 0x00, b'a', b'b'];
-        assert_eq!(parse_xattr_value(&short), b"ab".to_vec());
-        // value shorter than the header: pass through
-        assert_eq!(parse_xattr_value(b"abc"), b"abc".to_vec());
+        assert_eq!(parse_xattr_value(&short).unwrap(), b"ab".to_vec());
+        // value shorter than the header: rejected rather than passed through
+        assert!(parse_xattr_value(b"abc").is_err());
+        // data-stream attribute: rejected rather than returned as data
+        let dstream = [0x01, 0x00, 0x10, 0x00, 0xAA, 0xBB, 0xCC, 0xDD];
+        assert!(parse_xattr_value(&dstream).is_err());
     }
 
-    #[test]
-    fn builds_xattr_search_key_layout() {
-        // The search key must match the on-disk j_xattr_key_t layout:
-        // obj_id_and_type | name_len (incl. NUL) | name | NUL
-        let oid = 25_u64;
-        let name = "com.apple.fs.symlink";
+    /// Build an on-disk catalog key: `obj_id_and_type | name_len u16 | name | NUL`.
+    fn xattr_key(oid: u64, j_type: u8, name: &str) -> Vec<u8> {
         let mut key = Vec::with_capacity(8 + 2 + name.len() + 1);
-        let obj_id_and_type = (oid & 0x0FFFFFFFFFFFFFFF) | ((J_TYPE_XATTR as u64) << 60);
+        let obj_id_and_type = (oid & 0x0FFFFFFFFFFFFFFF) | ((j_type as u64) << 60);
         key.extend_from_slice(&obj_id_and_type.to_le_bytes());
         key.extend_from_slice(&((name.len() + 1) as u16).to_le_bytes());
         key.extend_from_slice(name.as_bytes());
         key.push(0);
+        key
+    }
+
+    #[test]
+    fn xattr_key_layout_matches_on_disk_format() {
+        let key = xattr_key(25, J_TYPE_XATTR, SYMLINK_XATTR_NAME);
         assert_eq!(key.len(), 31);
         assert_eq!(key[0], 0x19); // oid 25, low byte
         assert_eq!(key[7], 0x40); // J_TYPE_XATTR nibble
-        assert_eq!(&key[8..10], &[0x15, 0x00]); // name_len 21
-        assert_eq!(&key[10..31], b"com.apple.fs.symlink\0");
+        assert_eq!(&key[8..10], &[0x15, 0x00]); // name_len 21, incl. NUL
+        assert_eq!(&key[XATTR_KEY_NAME_OFFSET..], b"com.apple.fs.symlink\0");
+    }
+
+    #[test]
+    fn compares_xattr_keys_by_oid_then_type_then_name() {
+        use std::cmp::Ordering;
+        // The comparator matches against the NUL-terminated attribute name.
+        let mut want = SYMLINK_XATTR_NAME.as_bytes().to_vec();
+        want.push(0);
+
+        // Exact match.
+        assert_eq!(
+            compare_xattr_key(&xattr_key(25, J_TYPE_XATTR, SYMLINK_XATTR_NAME), 25, &want),
+            Ordering::Equal
+        );
+
+        // OID dominates, and is compared numerically -- not as little-endian
+        // bytes, which would order 0x100 before 0x02.
+        assert_eq!(
+            compare_xattr_key(
+                &xattr_key(0x100, J_TYPE_XATTR, SYMLINK_XATTR_NAME),
+                0x02,
+                &want
+            ),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_xattr_key(
+                &xattr_key(0x02, J_TYPE_XATTR, SYMLINK_XATTR_NAME),
+                0x100,
+                &want
+            ),
+            Ordering::Less
+        );
+
+        // Same OID: the record type breaks the tie, even though it is packed
+        // into the high nibble of obj_id_and_type.
+        assert_eq!(
+            compare_xattr_key(&xattr_key(25, J_TYPE_INODE, ""), 25, &want),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_xattr_key(&xattr_key(25, J_TYPE_DIR_REC, ""), 25, &want),
+            Ordering::Greater
+        );
+
+        // Same OID and type: names order by bytes, ignoring the name_len field
+        // that precedes them -- a longer name can still sort first.
+        assert_eq!(
+            compare_xattr_key(
+                &xattr_key(25, J_TYPE_XATTR, "com.apple.diskimages.recentcksum"),
+                25,
+                &want
+            ),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_xattr_key(
+                &xattr_key(25, J_TYPE_XATTR, "com.apple.quarantine"),
+                25,
+                &want
+            ),
+            Ordering::Greater
+        );
+
+        // Undecodable keys are treated as "before the target" so the scan
+        // keeps going rather than terminating early.
+        assert_eq!(compare_xattr_key(b"short", 25, &want), Ordering::Less);
     }
 
     fn open_volume() -> (BufReader<std::fs::File>, u64, u64, u32) {

--- a/apfs/src/error.rs
+++ b/apfs/src/error.rs
@@ -23,6 +23,9 @@ pub enum ApfsError {
     #[error("corrupted data: {0}")]
     CorruptedData(String),
 
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+
     #[error("no volume found in container")]
     NoVolume,
 }

--- a/apfs/src/fletcher.rs
+++ b/apfs/src/fletcher.rs
@@ -16,8 +16,8 @@ pub fn fletcher64(data: &[u8]) -> u64 {
     let mut sum2: u64 = 0;
 
     // Process 4 bytes at a time (little-endian u32)
-    for chunk in data.chunks_exact(4) {
-        let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]) as u64;
+    for chunk in data.as_chunks::<4>().0 {
+        let word = u32::from_le_bytes(*chunk) as u64;
         sum1 = (sum1 + word) % mod_val;
         sum2 = (sum2 + sum1) % mod_val;
     }

--- a/apfs/src/lib.rs
+++ b/apfs/src/lib.rs
@@ -183,15 +183,45 @@ impl<R: Read + Seek> ApfsVolume<R> {
         Ok(buf)
     }
 
+    /// Symlink targets on APFS are stored in a "com.apple.fs.symlink"
+    /// extended attribute (NUL-terminated), not as file data. Returns the
+    /// target bytes for symlink inodes, or None when no xattr is present.
+    fn symlink_target(&mut self, oid: u64) -> Result<Option<Vec<u8>>> {
+        let Some(xattr) = catalog::lookup_xattr(
+            &mut self.reader,
+            self.catalog_root_block,
+            self.vol_omap_root_block,
+            self.block_size,
+            oid,
+            catalog::SYMLINK_XATTR_NAME,
+        )?
+        else {
+            return Ok(None);
+        };
+        let data = catalog::parse_xattr_value(&xattr);
+        let end = data.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+        Ok(Some(data[..end].to_vec()))
+    }
+
     /// Stream a file to a writer
     pub fn read_file_to<W: Write>(&mut self, path: &str, writer: &mut W) -> Result<u64> {
-        let (_oid, inode) = catalog::resolve_path(
+        let (oid, inode) = catalog::resolve_path(
             &mut self.reader,
             self.catalog_root_block,
             self.vol_omap_root_block,
             self.block_size,
             path,
         )?;
+
+        // Symlink inodes carry no extents; read the target from the xattr.
+        if inode.kind() == catalog::INODE_SYMLINK_TYPE {
+            if let Some(target) = self.symlink_target(oid)? {
+                writer.write_all(&target)?;
+                return Ok(target.len() as u64);
+            }
+            // Fall back to the extent read for images that store the
+            // target as file data.
+        }
 
         // File extents are keyed by private_id, not the inode OID
         let file_extents = catalog::lookup_extents(
@@ -248,6 +278,14 @@ impl<R: Read + Seek> ApfsVolume<R> {
             path,
         )?;
 
+        // Symlink inodes report size 0; use the xattr target length instead.
+        let size = if inode.kind() == catalog::INODE_SYMLINK_TYPE {
+            self.symlink_target(oid)?
+                .map_or(inode.size(), |t| t.len() as u64)
+        } else {
+            inode.size()
+        };
+
         Ok(FileStat {
             oid,
             kind: match inode.kind() {
@@ -255,7 +293,7 @@ impl<R: Read + Seek> ApfsVolume<R> {
                 catalog::INODE_SYMLINK_TYPE => EntryKind::Symlink,
                 _ => EntryKind::File,
             },
-            size: inode.size(),
+            size,
             create_time: inode.create_time,
             modify_time: inode.modify_time,
             uid: inode.uid,

--- a/apfs/src/lib.rs
+++ b/apfs/src/lib.rs
@@ -198,9 +198,8 @@ impl<R: Read + Seek> ApfsVolume<R> {
         else {
             return Ok(None);
         };
-        let data = catalog::parse_xattr_value(&xattr);
-        let end = data.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
-        Ok(Some(data[..end].to_vec()))
+        let end = xattr.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+        Ok(Some(xattr[..end].to_vec()))
     }
 
     /// Stream a file to a writer
@@ -214,13 +213,13 @@ impl<R: Read + Seek> ApfsVolume<R> {
         )?;
 
         // Symlink inodes carry no extents; read the target from the xattr.
-        if inode.kind() == catalog::INODE_SYMLINK_TYPE {
-            if let Some(target) = self.symlink_target(oid)? {
-                writer.write_all(&target)?;
-                return Ok(target.len() as u64);
-            }
-            // Fall back to the extent read for images that store the
-            // target as file data.
+        // Falls through to the extent read for images that store the target
+        // as file data.
+        if inode.kind() == catalog::INODE_SYMLINK_TYPE
+            && let Some(target) = self.symlink_target(oid)?
+        {
+            writer.write_all(&target)?;
+            return Ok(target.len() as u64);
         }
 
         // File extents are keyed by private_id, not the inode OID
@@ -412,5 +411,47 @@ mod tests {
 
         let stat = vol.stat(&entry.path).unwrap();
         assert_eq!(stat.size, entry.entry.size);
+    }
+
+    /// Requires ../tests/appfs.raw fixture. Run with `cargo test -- --ignored`.
+    #[test]
+    #[ignore]
+    fn test_read_symlink_targets() {
+        let file = std::fs::File::open("../tests/appfs.raw").unwrap();
+        let reader = BufReader::new(file);
+
+        let mut vol = ApfsVolume::open(reader).unwrap();
+
+        let walk = vol.walk().unwrap();
+        let symlinks: Vec<_> = walk
+            .iter()
+            .filter(|e| e.entry.kind == EntryKind::Symlink)
+            .map(|e| e.path.clone())
+            .collect();
+        assert!(
+            !symlinks.is_empty(),
+            "Test image should contain symlinks to read"
+        );
+
+        for path in &symlinks {
+            let target = vol.read_file(path).unwrap();
+            assert!(
+                !target.is_empty(),
+                "Symlink {path} should resolve to a non-empty target"
+            );
+            assert!(
+                !target.contains(&0),
+                "Symlink target for {path} should have its trailing NUL stripped"
+            );
+
+            // stat() reports the target length, not the inode's zero size.
+            let stat = vol.stat(path).unwrap();
+            assert_eq!(stat.kind, EntryKind::Symlink);
+            assert_eq!(
+                stat.size,
+                target.len() as u64,
+                "stat size should match the target length for {path}"
+            );
+        }
     }
 }

--- a/dpp-python/CHANGELOG.md
+++ b/dpp-python/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Map `ApfsError::Unsupported` to `UnsupportedError`, alongside the existing unsupported-version and unsupported-encoding mappings
+
 ## [0.2.1] - 2026-04-12
 
 ### Changed

--- a/dpp-python/src/error.rs
+++ b/dpp-python/src/error.rs
@@ -124,6 +124,7 @@ fn apfs_to_pyerr(apfs_err: &dpp::apfs::ApfsError, top: &dpp::DppError) -> PyErr 
         | A::NotADirectory(_)
         | A::CorruptedData(_)
         | A::NoVolume => InvalidFormatError::new_err(top.to_string()),
+        A::Unsupported(_) => UnsupportedError::new_err(top.to_string()),
     }
 }
 

--- a/dpp-tool/src/cmd_payload.rs
+++ b/dpp-tool/src/cmd_payload.rs
@@ -348,21 +348,9 @@ fn find(
 
             if let Some(tf) = type_filter {
                 match tf {
-                    "f" => {
-                        if e.is_dir || e.is_symlink {
-                            return false;
-                        }
-                    }
-                    "d" => {
-                        if !e.is_dir {
-                            return false;
-                        }
-                    }
-                    "l" => {
-                        if !e.is_symlink {
-                            return false;
-                        }
-                    }
+                    "f" if e.is_dir || e.is_symlink => return false,
+                    "d" if !e.is_dir => return false,
+                    "l" if !e.is_symlink => return false,
                     _ => {}
                 }
             }

--- a/hfsplus/src/unicode.rs
+++ b/hfsplus/src/unicode.rs
@@ -167,8 +167,10 @@ pub fn compare_case_insensitive(a: &[u16], b: &[u16]) -> std::cmp::Ordering {
 /// Convert a UTF-16BE byte slice to a `Vec<u16>` of code points
 pub fn utf16be_to_u16(bytes: &[u8]) -> Vec<u16> {
     bytes
-        .chunks_exact(2)
-        .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|chunk| u16::from_be_bytes(*chunk))
         .collect()
 }
 


### PR DESCRIPTION
## Problem

On APFS, symlink targets are stored in a catalog **extended attribute** record (`J_TYPE_XATTR` = 4) named `com.apple.fs.symlink`, rather than as ordinary file data. Symlink inodes carry no extents and report an `uncompressed_size` of 0, so `ApfsVolume::read_file` / `read_file_to` previously returned empty bytes for these symlinks.

This was reproduced with `hdiutil create -srcfolder` images on macOS 26: a symlink such as `readme-link.txt -> ../README.txt` read as 0 bytes.

## Fix

- Add `catalog::lookup_xattr`, keyed using the on-disk `j_xattr_key_t` layout and ordered through `compare_catalog_keys` by OID, record type, and name.
- Parse the xattr value inside the catalog layer and return the payload to callers.
- Add `ApfsError::Unsupported` for well-formed xattrs that use unsupported data-stream storage.
- Have `ApfsVolume::read_file_to` return the NUL-trimmed `com.apple.fs.symlink` payload for symlink inodes, with the existing extent read retained as a fallback.
- Have `ApfsVolume::stat` report the symlink target length instead of 0.

## API note

This adds the public `ApfsError::Unsupported` variant. Downstream code that exhaustively matches `ApfsError` must add a matching arm. Existing consumers that do not exhaustively match the enum, including the checked ZManager integration, require no code changes.

## Verification

- Unit coverage for the xattr key/value layouts and catalog-key ordering tie-breaks.
- Maintainer fixture coverage for all 15 symlinks in the non-public `tests/appfs.raw` image.
- `hdiutil`-created HFS+ and APFS images return `../README.txt` (13 bytes) for the example symlink.
- Rust 1.98 local verification at `e5516f4`: formatting passed; Clippy passed with warnings denied; 107 tests passed with 25 fixture-dependent tests ignored; parallel-feature tests passed; documentation passed with warnings denied.
- The fresh GitHub Actions run for `e5516f4` is awaiting upstream workflow approval before the hosted Ubuntu, macOS, and Windows jobs can start.

## Acknowledgements

Many thanks to @Dil4rd for the careful review and guidance, and for directly contributing the catalog-ordering correction, parsed xattr handling, unsupported-feature error, changelog updates, comparator coverage, and private-fixture test. Those follow-up fixes made the implementation substantially more robust.
