### PR TITLE
Support base64-encoded XAR filenames

### DIFF
--- a/xara/CHANGELOG.md
+++ b/xara/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Scope file metadata and payload descriptors to their exact TOC ancestry
 - Preserve complete file names and symlink targets across text, CDATA, and comments
 - Bound heap entry reads and reject offset or decoded-size inconsistencies
+- Decode `<name enctype="base64">`, which macOS `xar` uses for names that
+  aren't safe as bare XML text (observed for non-ASCII names); previously the
+  raw base64 text was surfaced as the entry's name and path
 
 ## [0.3.2] - 2026-04-12
 

--- a/xara/CHANGELOG.md
+++ b/xara/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Scope file metadata and payload descriptors to their exact TOC ancestry
 - Preserve complete file names and symlink targets across text, CDATA, and comments
 - Bound heap entry reads and reject offset or decoded-size inconsistencies
-- Decode `<name enctype="base64">`, which macOS `xar` uses for names that
-  aren't safe as bare XML text (observed for non-ASCII names); previously the
+- Decode `<name enctype="base64">`, which macOS `xar` uses for names whose
+  UTF-8 values aren't representable in ISO-8859-1 (for example, non-Latin
+  names); previously the
   raw base64 text was surfaced as the entry's name and path
 
 ## [0.3.2] - 2026-04-12

--- a/xara/Cargo.toml
+++ b/xara/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["xar", "pkg", "apple", "macos", "archive"]
 categories = ["parsing", "compression"]
 
 [dependencies]
+base64 = "0.22"
 byteorder = "1.5"
 thiserror = "2"
 flate2 = "1.0"

--- a/xara/docs/FORMATS.md
+++ b/xara/docs/FORMATS.md
@@ -90,6 +90,22 @@ child of the file entry:
 </file>
 ```
 
+### Base64-Encoded Names
+
+A `<name>` element that isn't safe as bare XML text carries `enctype="base64"`
+and holds the base64 encoding of the real, UTF-8 name in place of the literal
+text. macOS `xar` does this for names containing non-ASCII characters:
+
+```xml
+<file id="5">
+  <name enctype="base64">44GT44KT44Gr44Gh44GvLnR4dA==</name>
+  <type>file</type>
+</file>
+```
+
+decodes to the name `こんにちは.txt`. Any other `enctype` value, or base64 or
+UTF-8 that fails to decode, is a parse error.
+
 ### Data Encoding Styles
 
 | Style | Description |

--- a/xara/docs/FORMATS.md
+++ b/xara/docs/FORMATS.md
@@ -92,9 +92,10 @@ child of the file entry:
 
 ### Base64-Encoded Names
 
-A `<name>` element that isn't safe as bare XML text carries `enctype="base64"`
-and holds the base64 encoding of the real, UTF-8 name in place of the literal
-text. macOS `xar` does this for names containing non-ASCII characters:
+A `<name>` element whose UTF-8 value is not representable in ISO-8859-1
+carries `enctype="base64"` and holds the base64 encoding of the real name in
+place of the literal text. macOS `xar` does this for names outside the
+ISO-8859-1 repertoire, such as Japanese characters:
 
 ```xml
 <file id="5">
@@ -103,8 +104,9 @@ text. macOS `xar` does this for names containing non-ASCII characters:
 </file>
 ```
 
-decodes to the name `こんにちは.txt`. Any other `enctype` value, or base64 or
-UTF-8 that fails to decode, is a parse error.
+decodes to the name `こんにちは.txt`. Base64 line wrapping whitespace is
+ignored. Any other `enctype` value, or base64 or UTF-8 that fails to decode, is
+a parse error.
 
 ### Data Encoding Styles
 

--- a/xara/src/lib.rs
+++ b/xara/src/lib.rs
@@ -474,6 +474,32 @@ mod tests {
     }
 
     #[test]
+    fn test_open_and_extract_base64_encoded_name() {
+        use base64::Engine;
+
+        let name = "こんにちは.txt";
+        let encoded_name = base64::engine::general_purpose::STANDARD.encode(name.as_bytes());
+        let toc_xml = format!(
+            "<xar><toc><file id=\"1\"><name enctype=\"base64\">{encoded_name}</name><type>file</type><data><offset>0</offset><length>7</length><size>7</size><encoding style=\"application/octet-stream\"/></data></file></toc></xar>"
+        );
+
+        let xar_buf = build_test_xar(toc_xml.as_bytes(), b"payload");
+        let mut archive = XarArchive::open(Cursor::new(&xar_buf)).unwrap();
+
+        let file = archive
+            .find(name)
+            .expect("decoded name should be searchable")
+            .clone();
+        assert_eq!(file.name, name);
+        assert_eq!(archive.read_file(&file).unwrap(), b"payload");
+
+        let tmp = tempfile::tempdir().unwrap();
+        let stats = archive.extract_all(tmp.path()).unwrap();
+        assert_eq!(stats.files, 1);
+        assert_eq!(std::fs::read(tmp.path().join(name)).unwrap(), b"payload");
+    }
+
+    #[test]
     fn test_extract_rejects_base64_name_decoding_to_traversal() {
         // "Li4v...cGFzc3dk" is the base64 encoding of "../../etc/passwd". A
         // maliciously crafted XAR could set enctype="base64" on a <name> to

--- a/xara/src/lib.rs
+++ b/xara/src/lib.rs
@@ -472,4 +472,39 @@ mod tests {
         assert!(tmp.path().join("real.txt").exists());
         assert!(!tmp.path().join("link.txt").exists());
     }
+
+    #[test]
+    fn test_extract_rejects_base64_name_decoding_to_traversal() {
+        // "Li4v...cGFzc3dk" is the base64 encoding of "../../etc/passwd". A
+        // maliciously crafted XAR could set enctype="base64" on a <name> to
+        // smuggle a traversal payload through decoding; sanitize_path must
+        // still catch it post-decode, same as it does for a literal name.
+        let toc_xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<xar>
+  <toc>
+    <file id="1">
+      <name enctype="base64">Li4vLi4vZXRjL3Bhc3N3ZA==</name>
+      <type>file</type>
+      <data>
+        <offset>0</offset>
+        <length>4</length>
+        <size>4</size>
+        <encoding style="application/octet-stream"/>
+      </data>
+    </file>
+  </toc>
+</xar>"#;
+
+        let xar_buf = build_test_xar(toc_xml, b"data");
+        let mut cursor = Cursor::new(&xar_buf);
+        let mut archive = XarArchive::open(&mut cursor).unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let result = archive.extract_all(tmp.path());
+
+        assert!(
+            matches!(result, Err(XarError::InvalidPath(_))),
+            "expected traversal rejection, got {result:?}"
+        );
+    }
 }

--- a/xara/src/toc.rs
+++ b/xara/src/toc.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use flate2::read::ZlibDecoder;
 use quick_xml::Reader;
 use quick_xml::events::{BytesStart, Event};
@@ -163,6 +164,11 @@ impl FileDataBuilder {
 struct FileBuilder {
     id: u64,
     name: String,
+    /// `enctype` attribute captured from `<name>`, if any. macOS `xar` sets
+    /// `enctype="base64"` when a name isn't safe as bare XML text (observed
+    /// for non-ASCII names). Consumed by `assign_text` when the `<name>`
+    /// capture closes.
+    name_enctype: Option<String>,
     file_type: Option<String>,
     link: Option<String>,
     children: Vec<usize>,
@@ -208,7 +214,7 @@ impl FileBuilder {
         }
         self.assigned_fields.push(field);
         match field {
-            CaptureField::Name => self.name = value,
+            CaptureField::Name => self.name = decode_name(value, self.name_enctype.take())?,
             CaptureField::FileType => self.file_type = Some(value.trim().to_string()),
             CaptureField::Link => self.link = Some(value),
             CaptureField::DataOffset => {
@@ -272,6 +278,31 @@ fn parse_u64_field(name: &str, value: &str) -> Result<u64> {
         .trim()
         .parse()
         .map_err(|error| XarError::XmlParse(format!("invalid <{name}> value {value:?}: {error}")))
+}
+
+/// Decode a `<name>` element's text, applying the `enctype` attribute
+/// captured from its start tag. macOS `xar` sets `enctype="base64"` when a
+/// name isn't safe as bare XML text (observed for non-ASCII names); the text
+/// content is then the base64 encoding of the real, UTF-8 name.
+fn decode_name(value: String, enctype: Option<String>) -> Result<String> {
+    match enctype.as_deref() {
+        None => Ok(value),
+        Some("base64") => {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(value.trim())
+                .map_err(|error| {
+                    XarError::XmlParse(format!("invalid base64 <name> value {value:?}: {error}"))
+                })?;
+            String::from_utf8(decoded).map_err(|error| {
+                XarError::XmlParse(format!(
+                    "<name enctype=\"base64\"> decoded to invalid UTF-8: {error}"
+                ))
+            })
+        }
+        Some(other) => Err(XarError::XmlParse(format!(
+            "unsupported <name> enctype {other:?}"
+        ))),
+    }
 }
 
 fn current_file(stack: &mut [FileBuilder]) -> Result<&mut FileBuilder> {
@@ -366,6 +397,7 @@ fn parse_toc_xml(xml: &[u8]) -> Result<Vec<XarFile>> {
                         stack.push(FileBuilder {
                             id,
                             name: String::new(),
+                            name_enctype: None,
                             file_type: None,
                             link: None,
                             children: Vec::new(),
@@ -390,7 +422,10 @@ fn parse_toc_xml(xml: &[u8]) -> Result<Vec<XarFile>> {
                         ElementContext::FileData
                     }
                     b"name" if parent == Some(ElementContext::File) => {
-                        current_file(&mut stack)?.begin_capture(CaptureField::Name, depth)?;
+                        let enctype = attribute_value(&reader, e, b"enctype")?;
+                        let file = current_file(&mut stack)?;
+                        file.name_enctype = enctype;
+                        file.begin_capture(CaptureField::Name, depth)?;
                         ElementContext::Other
                     }
                     b"type" if parent == Some(ElementContext::File) => {
@@ -470,7 +505,11 @@ fn parse_toc_xml(xml: &[u8]) -> Result<Vec<XarFile>> {
                             "file <data> is missing <offset>, <length>, and <size>".to_string(),
                         ));
                     }
-                    b"name" if parent == Some(ElementContext::File) => Some(CaptureField::Name),
+                    b"name" if parent == Some(ElementContext::File) => {
+                        let enctype = attribute_value(&reader, e, b"enctype")?;
+                        current_file(&mut stack)?.name_enctype = enctype;
+                        Some(CaptureField::Name)
+                    }
                     b"type" if parent == Some(ElementContext::File) => Some(CaptureField::FileType),
                     b"link" if parent == Some(ElementContext::File) => Some(CaptureField::Link),
                     b"offset" if parent == Some(ElementContext::FileData) => {
@@ -991,5 +1030,61 @@ mod tests {
         for xml in cases {
             assert!(matches!(parse_toc_xml(xml), Err(XarError::XmlParse(_))));
         }
+    }
+
+    #[test]
+    fn decodes_base64_encoded_name() {
+        // Real bytes from fixtures/archives/basic.xar's TOC: macOS `xar` sets
+        // enctype="base64" for names that aren't safe as bare XML text. This
+        // is the base64 encoding of "こんにちは.txt".
+        let xml = br#"<xar><toc>
+  <file id="1">
+    <type>file</type>
+    <name enctype="base64">44GT44KT44Gr44Gh44GvLnR4dA==</name>
+  </file>
+</toc></xar>"#;
+
+        let files = parse_toc_xml(xml).unwrap();
+        assert_eq!(files[0].name, "こんにちは.txt");
+        assert_eq!(files[0].path, "こんにちは.txt");
+    }
+
+    #[test]
+    fn base64_name_decoding_applies_within_nested_directories() {
+        let xml = br#"<xar><toc>
+  <file id="1">
+    <type>directory</type>
+    <name>unicode</name>
+    <file id="2">
+      <type>file</type>
+      <name enctype="base64">44GT44KT44Gr44Gh44GvLnR4dA==</name>
+    </file>
+  </file>
+</toc></xar>"#;
+
+        let files = parse_toc_xml(xml).unwrap();
+        let child = files.iter().find(|f| f.id == 2).unwrap();
+        assert_eq!(child.name, "こんにちは.txt");
+        assert_eq!(child.path, "unicode/こんにちは.txt");
+    }
+
+    #[test]
+    fn rejects_unsupported_name_enctype() {
+        let xml = br#"<xar><toc><file id="1"><type>file</type><name enctype="quoted-printable">entry</name></file></toc></xar>"#;
+        assert!(matches!(parse_toc_xml(xml), Err(XarError::XmlParse(_))));
+    }
+
+    #[test]
+    fn rejects_invalid_base64_name() {
+        let xml = br#"<xar><toc><file id="1"><type>file</type><name enctype="base64">not valid base64!!</name></file></toc></xar>"#;
+        assert!(matches!(parse_toc_xml(xml), Err(XarError::XmlParse(_))));
+    }
+
+    #[test]
+    fn rejects_base64_name_decoding_to_invalid_utf8() {
+        // "//4=" is the base64 encoding of the two bytes 0xFF 0xFE, which is
+        // not valid UTF-8.
+        let xml = br#"<xar><toc><file id="1"><type>file</type><name enctype="base64">//4=</name></file></toc></xar>"#;
+        assert!(matches!(parse_toc_xml(xml), Err(XarError::XmlParse(_))));
     }
 }

--- a/xara/src/toc.rs
+++ b/xara/src/toc.rs
@@ -288,8 +288,16 @@ fn decode_name(value: String, enctype: Option<String>) -> Result<String> {
     match enctype.as_deref() {
         None => Ok(value),
         Some("base64") => {
+            // Apple's XAR writer may wrap long base64 values with CRLF line
+            // breaks. Ignore ASCII whitespace as part of the base64
+            // transport, while leaving all other invalid bytes for the
+            // decoder to reject.
+            let compact_value = value
+                .bytes()
+                .filter(|byte| !byte.is_ascii_whitespace())
+                .collect::<Vec<_>>();
             let decoded = base64::engine::general_purpose::STANDARD
-                .decode(value.trim())
+                .decode(compact_value)
                 .map_err(|error| {
                     XarError::XmlParse(format!("invalid base64 <name> value {value:?}: {error}"))
                 })?;
@@ -1035,8 +1043,8 @@ mod tests {
     #[test]
     fn decodes_base64_encoded_name() {
         // Real bytes from fixtures/archives/basic.xar's TOC: macOS `xar` sets
-        // enctype="base64" for names that aren't safe as bare XML text. This
-        // is the base64 encoding of "こんにちは.txt".
+        // enctype="base64" for names that aren't representable in
+        // ISO-8859-1. This is the base64 encoding of "こんにちは.txt".
         let xml = br#"<xar><toc>
   <file id="1">
     <type>file</type>
@@ -1066,6 +1074,29 @@ mod tests {
         let child = files.iter().find(|f| f.id == 2).unwrap();
         assert_eq!(child.name, "こんにちは.txt");
         assert_eq!(child.path, "unicode/こんにちは.txt");
+    }
+
+    #[test]
+    fn accepts_line_wrapped_base64_encoded_name() {
+        const APPLE_XAR_BASE64_LINE_LENGTH: usize = 72;
+
+        let name = "これはとても長いファイル名であり、XARのbase64ラッピングを検証します.txt";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(name.as_bytes());
+        let wrapped = encoded
+            .as_bytes()
+            .chunks(APPLE_XAR_BASE64_LINE_LENGTH)
+            .map(|chunk| std::str::from_utf8(chunk).unwrap())
+            .collect::<Vec<_>>()
+            .join("\r\n");
+        assert!(wrapped.contains("\r\n"));
+
+        let xml = format!(
+            "<xar><toc><file id=\"1\"><type>file</type><name enctype=\"base64\">{wrapped}</name></file></toc></xar>"
+        );
+
+        let files = parse_toc_xml(xml.as_bytes()).unwrap();
+        assert_eq!(files[0].name, name);
+        assert_eq!(files[0].path, name);
     }
 
     #[test]

--- a/xara/src/toc.rs
+++ b/xara/src/toc.rs
@@ -281,9 +281,9 @@ fn parse_u64_field(name: &str, value: &str) -> Result<u64> {
 }
 
 /// Decode a `<name>` element's text, applying the `enctype` attribute
-/// captured from its start tag. macOS `xar` sets `enctype="base64"` when a
-/// name isn't safe as bare XML text (observed for non-ASCII names); the text
-/// content is then the base64 encoding of the real, UTF-8 name.
+/// captured from its start tag. macOS `xar` sets `enctype="base64"` when the
+/// name's UTF-8 value is not representable in ISO-8859-1; the text content is
+/// then the base64 encoding of the real name.
 fn decode_name(value: String, enctype: Option<String>) -> Result<String> {
     match enctype.as_deref() {
         None => Ok(value),


### PR DESCRIPTION
## Summary

macOS XAR archives can encode filenames as `<name enctype="base64">` when their UTF-8 values are outside the ISO-8859-1 repertoire.

This PR:

- Decodes standard-base64 XAR names back to UTF-8 filenames.
- Accepts ASCII whitespace used for wrapped base64 values while rejecting other invalid input.
- Preserves existing invalid-UTF-8 and traversal-safety behavior.
- Adds unit and public end-to-end regression coverage, including `こんにちは.txt`.
- Documents the format behavior.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --exclude dpp-python`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --exclude dpp-python`